### PR TITLE
Add support for cluster workflows

### DIFF
--- a/applications/DeepSpeed-Chat/docker-compose.yml
+++ b/applications/DeepSpeed-Chat/docker-compose.yml
@@ -3,6 +3,12 @@ services:
     build:
       context: .
       dockerfile: ${DOCKERFILE_PATH:-dockerfiles/Dockerfile-A10}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            # Ensure GPU access
+            - capabilities: [gpu]
     image: deepspeed-training:latest
     container_name: deepspeed-training
     cap_add:
@@ -35,7 +41,12 @@ services:
         hard: -1
     
     command: /workspace/DeepSpeedExamples/applications/DeepSpeed-Chat/docker_scripts/entrypoint.sh
-    
+
+    # Mount infiniband devices
+    # Silently fails if not present on host
+    devices:
+      - "/dev/infiniband:/dev/infiniband"
+   
     environment:
       - PROJECT_PATH=${PROJECT_PATH:-/workspace}
       - HF_HOME=${PROJECT_PATH:-/workspace}/.cache/huggingface
@@ -58,6 +69,13 @@ services:
       # Volume is temporary because we need to change the permissions on .ssh files to root
       # within the container
       - ~/.ssh:/tmp/host_ssh:ro
+
+      # Mount infiniband configurations and libraries
+      # Creates empty directory on host if not present
+      - "/sys/class/infiniband:/sys/class/infiniband:ro"
+      - "/sys/class/net:/sys/class/net:ro"
+      - "/etc/libibverbs.d:/etc/libibverbs.d:ro"
+
     
     stdin_open: true
     tty: true

--- a/applications/DeepSpeed-Chat/docker-compose.yml
+++ b/applications/DeepSpeed-Chat/docker-compose.yml
@@ -7,6 +7,16 @@ services:
     container_name: deepspeed-training
     cap_add:
       - IPC_LOCK
+
+    # Running in network-host mode ensures that the node network is visible to
+    # processes within the container.
+    # If running without host mode, DeepSpeed's master port must be exposed to
+    # the container.  I.e.
+    # ports:
+    #   - "${SSH_PORT:-22}:${SSH_PORT:-22}"
+    #   - "${DOCKER_MASTER_PORT:-29500}:${DOCKER_MASTER_PORT:-29500}"
+    network_mode: "host"
+    
     privileged: true
     runtime: nvidia
 
@@ -24,7 +34,7 @@ services:
         soft: -1
         hard: -1
     
-    command: /bin/bash -c "/usr/sbin/sshd && tail -f /dev/null"
+    command: /workspace/DeepSpeedExamples/applications/DeepSpeed-Chat/docker_scripts/entrypoint.sh
     
     environment:
       - PROJECT_PATH=${PROJECT_PATH:-/workspace}
@@ -33,6 +43,9 @@ services:
       - HF_DATASETS_CACHE=${PROJECT_PATH:-/workspace}/.cache/huggingface/datasets
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+      # Expose ports to the container environment
+      - SSH_PORT=${DOCKER_SSH_PORT:-5100}
+      - MASTER_PORT=${DOCKER_MASTER_PORT:-29500}
     
     volumes:
       # Mount DeepSpeedExamples repo to /workspace/DeepSpeedExamples
@@ -40,6 +53,11 @@ services:
       
       # Mount cache to /workspace/.cache
       - ${HOST_CACHE_PATH}:${PROJECT_PATH}/.cache:rw
+
+      # Mount ssh keys to a temporary volume
+      # Volume is temporary because we need to change the permissions on .ssh files to root
+      # within the container
+      - ~/.ssh:/tmp/host_ssh:ro
     
     stdin_open: true
     tty: true

--- a/applications/DeepSpeed-Chat/docker_scripts/entrypoint.sh
+++ b/applications/DeepSpeed-Chat/docker_scripts/entrypoint.sh
@@ -12,7 +12,9 @@ if [ -d /tmp/host_ssh ]; then
     cp -r /tmp/host_ssh/* /root/.ssh/
     chown -R root:root /root/.ssh
     chmod 700 /root/.ssh
-    chmod 600 /root/.ssh/id_rsa /root/.ssh/authorized_keys
+    for f in /root/.ssh/id_rsa /root/.ssh/id_ed25519 /root/.ssh/authorized_keys; do
+      [ -e "$f" ] && chmod 600 "$f"
+    done
     touch /root/.ssh/config
     chmod 600 /root/.ssh/config
     echo "StrictHostKeyChecking no" > /root/.ssh/config && \

--- a/applications/DeepSpeed-Chat/docker_scripts/entrypoint.sh
+++ b/applications/DeepSpeed-Chat/docker_scripts/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Change the container's SSH port to that specified by the env var SSH_PORT
+sed -i "s/^#Port 22/Port $SSH_PORT/" /etc/ssh/sshd_config
+echo "Set SSHD to port $SSH_PORT"
+
+# Copy SSH keys from mounted directory if present and not already set up
+# Change permissions to root
+if [ -d /tmp/host_ssh ]; then
+    echo "Copying SSH keys from /tmp/host_ssh to /root/.ssh..."
+    mkdir -p /root/.ssh
+    cp -r /tmp/host_ssh/* /root/.ssh/
+    chown -R root:root /root/.ssh
+    chmod 700 /root/.ssh
+    chmod 600 /root/.ssh/id_rsa /root/.ssh/authorized_keys
+    touch /root/.ssh/config
+    chmod 600 /root/.ssh/config
+    echo "StrictHostKeyChecking no" > /root/.ssh/config && \
+    echo "UserKnownHostsFile=/dev/null" >> /root/.ssh/config && \
+    cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys && \
+    echo "Finished SSH setup..."
+fi
+
+# Start SSHD
+/usr/sbin/sshd
+
+# Prevent container from exiting
+tail -f /dev/null
+

--- a/applications/DeepSpeed-Chat/dockerfiles/Dockerfile-A10
+++ b/applications/DeepSpeed-Chat/dockerfiles/Dockerfile-A10
@@ -28,15 +28,6 @@ RUN mkdir -p /var/run/sshd && \
     sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
     sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/' /etc/ssh/sshd_config
 
-# Setup passwordless SSH for localhost
-RUN mkdir -p /root/.ssh && chmod 700 /root/.ssh && \
-    ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa && \
-    cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys && \
-    chmod 600 /root/.ssh/authorized_keys /root/.ssh/id_rsa && \
-    echo "StrictHostKeyChecking no" > /root/.ssh/config && \
-    echo "UserKnownHostsFile=/dev/null" >> /root/.ssh/config && \
-    chmod 600 /root/.ssh/config
-
 # Upgrade pip
 RUN python -m pip install --upgrade pip setuptools wheel
 

--- a/applications/DeepSpeed-Chat/dockerfiles/Dockerfile-A10
+++ b/applications/DeepSpeed-Chat/dockerfiles/Dockerfile-A10
@@ -17,6 +17,10 @@ RUN apt-get update && apt-get install -y \
     openssh-client \
     nvtop \
     pdsh \
+    rdma-core \
+    ibverbs-providers \
+    libibverbs-dev \
+    libmlx5-1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Set python3.10 as default

--- a/applications/DeepSpeed-Chat/dockerfiles/Dockerfile-B200
+++ b/applications/DeepSpeed-Chat/dockerfiles/Dockerfile-B200
@@ -28,15 +28,6 @@ RUN mkdir -p /var/run/sshd && \
     sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
     sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/' /etc/ssh/sshd_config
 
-# Setup passwordless SSH for localhost
-RUN mkdir -p /root/.ssh && chmod 700 /root/.ssh && \
-    ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa && \
-    cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys && \
-    chmod 600 /root/.ssh/authorized_keys /root/.ssh/id_rsa && \
-    echo "StrictHostKeyChecking no" > /root/.ssh/config && \
-    echo "UserKnownHostsFile=/dev/null" >> /root/.ssh/config && \
-    chmod 600 /root/.ssh/config
-
 # Upgrade pip
 RUN python -m pip install --upgrade pip setuptools wheel
 

--- a/applications/DeepSpeed-Chat/dockerfiles/Dockerfile-B200
+++ b/applications/DeepSpeed-Chat/dockerfiles/Dockerfile-B200
@@ -17,6 +17,10 @@ RUN apt-get update && apt-get install -y \
     openssh-client \
     nvtop \
     pdsh \
+    rdma-core \
+    ibverbs-providers \
+    libibverbs-dev \
+    libmlx5-1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Set python3.10 as default

--- a/applications/DeepSpeed-Chat/dockerfiles/Dockerfile-H100
+++ b/applications/DeepSpeed-Chat/dockerfiles/Dockerfile-H100
@@ -28,15 +28,6 @@ RUN mkdir -p /var/run/sshd && \
     sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
     sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/' /etc/ssh/sshd_config
 
-# Setup passwordless SSH for localhost
-RUN mkdir -p /root/.ssh && chmod 700 /root/.ssh && \
-    ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa && \
-    cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys && \
-    chmod 600 /root/.ssh/authorized_keys /root/.ssh/id_rsa && \
-    echo "StrictHostKeyChecking no" > /root/.ssh/config && \
-    echo "UserKnownHostsFile=/dev/null" >> /root/.ssh/config && \
-    chmod 600 /root/.ssh/config
-
 # Upgrade pip
 RUN python -m pip install --upgrade pip setuptools wheel
 

--- a/applications/DeepSpeed-Chat/dockerfiles/Dockerfile-H100
+++ b/applications/DeepSpeed-Chat/dockerfiles/Dockerfile-H100
@@ -17,6 +17,10 @@ RUN apt-get update && apt-get install -y \
     openssh-client \
     nvtop \
     pdsh \
+    rdma-core \
+    ibverbs-providers \
+    libibverbs-dev \
+    libmlx5-1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Set python3.10 as default

--- a/applications/DeepSpeed-Chat/training/Tutorial.md
+++ b/applications/DeepSpeed-Chat/training/Tutorial.md
@@ -114,7 +114,8 @@ SSH into one of the nodes running the docker container and cd into the `training
 cd <path to root repository>/DeepSpeedExamples/applications/DeepSpeed-Chat/training
 ```
 
-Run the `run_docker_batch.sh` script on the desired scripts.  For example, to train the opt-350 and opt-13b models, run
+Run the `run_docker_batch.sh` script on the desired scripts.  For example, to train the opt-350 and opt-13b models on the example
+hostfile directory, run
 
 ```
 ./run_docker_batch.sh run_opt-350m_bs24_zero0 hostfiles/1node_1xN/ output/${USER}_1xN_opt-350m_bs24 3000

--- a/applications/DeepSpeed-Chat/training/Tutorial.md
+++ b/applications/DeepSpeed-Chat/training/Tutorial.md
@@ -35,6 +35,10 @@ HOST_REPO_PATH=/srv/nfs/staging/DeepSpeedExamples
 
 # CONTAINER PATHS (inside Docker)
 PROJECT_PATH=/workspace
+
+# PORTS
+DOCKER_SSH_PORT=5100        # optional; defaults to 5100
+DOCKER_MASTER_PORT=29500    # optional; defaults to 29500
 EOF
 ```
 
@@ -71,6 +75,9 @@ make env
 
 #### Step 2: Build and Run Container
 
+> [!WARNING]
+> These steps must be completed for all nodes participating in training.  It is recommended that you place the root DeepSpeedExamples repository in a shared filesystem, else environment variables, hostfiles, and outputs may not be correctly synced across devices.
+
 ```
 make build   # Build Docker image
 make run     # Start container
@@ -101,11 +108,17 @@ $ mkdir hostfiles/1node_1xN
 $ echo "localhost slots=1" > hostfiles/1node_1xN/hostfile_1xN_batch1
 ```
 
-Run the `run_batch.sh` script on the desired scripts.  For example, to train the opt-350 and opt-13b models, run
+SSH into one of the nodes running the docker container and cd into the `training` folder:
 
 ```
-./run_batch.sh run_opt-350m_bs24_zero0 hostfiles/1node_1xN/ output/${USER}_1xN_opt-350m_bs24 3000
-./run_batch.sh run_opt-13b_bs16_zero0 hostfiles/1node_1xN/ output/${USER}_1xN_opt-13b_bs16_zero0/ 600
+cd <path to root repository>/DeepSpeedExamples/applications/DeepSpeed-Chat/training
+```
+
+Run the `run_docker_batch.sh` script on the desired scripts.  For example, to train the opt-350 and opt-13b models, run
+
+```
+./run_docker_batch.sh run_opt-350m_bs24_zero0 hostfiles/1node_1xN/ output/${USER}_1xN_opt-350m_bs24 3000
+./run_docker_batch.sh run_opt-13b_bs16_zero0 hostfiles/1node_1xN/ output/${USER}_1xN_opt-13b_bs16_zero0/ 600
 ```
 
 > [!CAUTION]

--- a/applications/DeepSpeed-Chat/training/run_docker_batch.sh
+++ b/applications/DeepSpeed-Chat/training/run_docker_batch.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+if [ $# -ne 4 ]; then
+  echo "Usage: $0 <script_name> <hostfiles_folder_path> <output_folder_path> <timeout_seconds>"
+  exit 1
+fi
+
+script_name="$1"
+hostfiles_folder_path="$2"
+output_folder_path="$3"
+timeout_seconds="$4"
+
+if [ ! -d "$hostfiles_folder_path" ]; then
+  echo "Folder '$hostfiles_folder_path' does not exist."
+  exit 1
+fi
+
+mkdir -p $output_folder_path
+
+export PROJECT_PATH="/workspace"
+
+# Iterate through hostfiles in the folder
+for hostfile in "$hostfiles_folder_path"/hostfile_*; do
+  if [ -f "$hostfile" ]; then
+    # Extract the name without "hostfile_"
+    filename=$(basename "$hostfile")
+    job_name="${filename#hostfile_}"
+
+    cmd_job="export USER="root" && cd ${PROJECT_PATH}/DeepSpeedExamples/applications/DeepSpeed-Chat/training && ./${script_name}.sh $job_name $hostfiles_folder_path/$filename $output_folder_path"
+
+    # Submit the job to the running docker container
+    timeout ${timeout_seconds}s docker exec deepspeed-training bash -c "$cmd_job" &
+    echo "Job submitted for $hostfile"
+  fi
+  wait
+done
+
+# Wait for all background jobs to finish
+wait
+
+echo "All jobs finished."

--- a/applications/DeepSpeed-Chat/training/run_opt-350m_bs24_zero0.sh
+++ b/applications/DeepSpeed-Chat/training/run_opt-350m_bs24_zero0.sh
@@ -36,7 +36,7 @@ master_addr=$(echo "$first_line" | awk '{print $1}')
 deepspeed_path="deepspeed"
 
 source ./setup_env.sh $MODEL_NAME $STEP_NAME && \
-PROJECT_PATH=${PROJECT_PATH} $deepspeed_path --hostfile=$HOSTFILE_NAME --master_addr $master_addr $SCRIPT_PATH/main.py \
+PROJECT_PATH=${PROJECT_PATH} $deepspeed_path --hostfile=$HOSTFILE_NAME --ssh_port ${SSH_PORT:-22} --master_port ${MASTER_PORT:-29500} --master_addr $master_addr $SCRIPT_PATH/main.py \
    --data_path Dahoas/rm-static Dahoas/full-hh-rlhf \
    --data_split 2,4,4 \
    --data_output_path $DATA_OUTPUT_PATH \

--- a/applications/DeepSpeed-Chat/training/utils/ds_utils.py
+++ b/applications/DeepSpeed-Chat/training/utils/ds_utils.py
@@ -56,7 +56,17 @@ def get_train_ds_config(offload,
             "enabled": enable_tensorboard,
             "output_path": f"{tb_path}/ds_tensorboard_logs/",
             "job_name": f"{tb_name}_tensorboard"
-        }
+        },
+        "logging": {
+            "path": "./logs",
+            "level": "debug"
+        },
+        "comms_logger": {
+            "enabled": True,
+            "verbose": False,
+            "prof_all": True,
+            "debug": True,
+        },
     }
 
 


### PR DESCRIPTION
3/3

Adds the ability to run workflows when nodes are connected by a network via a `run_docker_batch.sh` script.

Tested on bond0, eno1, and ib networks for 2-node clusters of B200s.

`run_opt-350m_bs24_zero0.sh` has been modified as an example for scripts that can be run using the new `run_docker_batch.sh` script